### PR TITLE
Feature/project build

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,12 +16,64 @@
     
 * Walkthrough
   =tangld= provides three basic functions:
-  - tangld-init :: =tangld= sets up a new, local repository for managing the configuration files.
-  - tangld-config :: =tangld= gathers environment, system and user settings and stores them in your local =tangld
+  - [ ] tangld-init :: =tangld= sets up a new, local repository for managing the configuration files.
+  - [ ] tangld-config :: =tangld= gathers environment, system and user settings and stores them in your local =tangld
     project= 
-  - tangld-build :: =tangld= calls =org-babel-tangle= on all of your source files, which produce your system's
+  - [ ] tangld-build :: =tangld= calls =org-babel-tangle= on all of your source files, which produce your system's
     configuration files.
 
-  Using these three functions, tangld provides the same functionality that a build system such as cmake, ant or
+  Using these three functions, tangld provides the same functionality as a build system such as cmake, ant or
   rake.
+
+* A tangld project
+  A project consists of :
+  - a unique (within this emacs session) name
+  - one or more source files (org-mode files to be tangled)
+  - zero or more include files (org-mode files to be ingested into the library of babel)
+  - zero or more configuration settings
+
+  As an example, if we have two source files 'fileA.org' and 'fileB.org, and we want two files to be loaded into the
+  library of babel first 'file1.org' and 'file2.org' , we can define the project like this:
+  #+begin_src emacs-lisp
+    (tangld-project-define "simple-tangld-project"
+      "This is a simple example tangld project"
+      :source ("fileA.org" "fileB.org")
+      :include ("file1.org" "file2.org"))
+  #+end_src
+
+  This project will be added to =tangld-projects-plist=.  Now to tangle the project, you can refer to it like so:
+  #+begin_src emacs-lisp
+    (tangld-build-project "simple-tangld-project")
+  #+end_src
+
+  Output of the build process is sent to the =*tangld*= buffer.
+
+  In addition to specifying a list of files, the =:source= and/or =:include= sections can have search criteria,
+  which tangld-project-define will use to build the list.
+
+    #+begin_src emacs-lisp
+    (tangld-project-define "all-config-files"
+      "All the files in my .tangld directory"
+      :source (:path "~/.tangld/src"        ; root directory to traverse
+                     :recurse t             ; look in subdirectories
+                     :files "\\.org$"       ; files to add to source
+                     :exclude "^\\."        ; unless they match this
+                     :exclude-dir "^\\."    ; don't look in these subdirs
+                     :include ".*default.*" ; cancel the exclusion for these
+                     )
+      :include (:path "~/.tangld/lib"       ; root directory to traverse
+                     :recurse t             ; look in subdirectories
+                     :files "\\.org$"       ; files to add to source
+                     :exclude "^\\."        ; unless they match this
+                     :exclude-dir "^\\."    ; don't look in these subdirs
+                     :include ".*default.*" ; cancel the exclusion for these
+                     )
+      :config (progn
+                (setq tangld-clear-library-before-build-p t)
+                ;...
+                ))
+  #+end_src
+  
+
+
   

--- a/src/tangld-build.el
+++ b/src/tangld-build.el
@@ -1,0 +1,186 @@
+;;; tangld-build.el --- literate config development environment -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Timothy Aldrich
+
+;; Author: Timothy Aldrich <timothy.r.aldrich@gmail.com>
+;; Version: 0.0.1
+;; Keywords: tools processes
+;; URL: https://github.com/aldrichtr/tangld
+
+;;; Commentary:
+;; A Literate Programming Environment for configuration files and scripts
+
+;; tangld is an Emacs package that provides 'dotfiles management' features
+;; using Literate Programming paradigms.  Using org-mode files with source
+;; blocks and the tangle functionality, Emacs can be used as an IDE to
+;; document, build, and install configuration files, scripts and other
+;; files on a system.  More details are available in the README.org file.
+
+;;; Code:
+
+;;;; Customization settings
+
+(defcustom tangld-pre-build-hook nil
+  "Hook run prior to building org-source files.  This hook runs prior to loading
+the library (or cache), and before the list of sources is built. Also see:
+ - `org-babel-pre-tangle-hook'  :: before each file is tangled
+ - `org-babel-tangle-body-hook' :: over the body of each source block"
+  :group 'tangld
+  :type 'hook)
+
+(defcustom tangld-post-build-hook nil
+  "Hook run after all org-source files have been tangled. Also see:
+ - `org-babel-post-tangle-hook' :: after each file is tangled"
+  :group 'tangld
+  :type 'hook)
+
+(defcustom tangld-clear-library-before-build-p t
+  "Clear the library-of-babel prior to build."
+  :group 'tangld
+  :type 'string)
+
+(defcustom tangld-build-file-regex "\\.org$"
+  "Regular expression used to gather files to be used in a project.  Combine regular
+expressions in `tangld-build-file-regex' ,`tangld-build-file-include-regex', 
+and `tangld-build-file-exclude-regex' to provide tangld-build fine-grained control
+over which files are ingested (library) and tangled (source)"
+  :group 'tangld
+  :type 'string)
+
+(defcustom tangld-build-file-include-regex "\\+"
+  "Regular expression used to match org-source file names that should be
+tangled.  By default any file that starts with '+' is included even if the 
+`tangld-build-file-exclude-regex' would match"
+  :group 'tangld
+  :type 'string)
+
+(defcustom tangld-build-file-exclude-regex "^_"
+  "Regular expression used to match org-source file names that should be
+skipped.  By default any file that starts with a '_' is skipped"
+  :group 'tangld
+  :type 'string)
+
+(defcustom tangld-build-dir-exclude-regex "^\\."
+  "Regular expression used to match org-source directory names that should be
+skipped.  By default any directory that starts with a '.' is skipped"
+  :group 'tangld
+  :type 'string)
+
+;;;; Build function
+
+(defun tangld-build-project (name &rest args)
+  "Build a project listed in `tangld-projects-plist' with the given name"
+  (interactive)
+  (let* ((project (lax-plist-get tangld-projects-plist name))
+         (sources (or (pop project) '()))
+         (includes (or (pop project) '()))
+         (config   (or (project)) '()))
+        (tangld-build sources includes config)))
+    
+
+(defun tangld-build (src &optional inc cfg)
+  "Call org-babel-tangle on each file in SRC.  If INC is present, call 'org-babel-lob-ingest' on
+each file prior to tangle."
+  (interactive)
+  ;; 1. Run any pre-build hooks
+  (run-hooks 'tangld-pre-build-hook)
+  ;; 2. Set options that control tangling
+  (setq org-confirm-babel-evaluate tangld-confirm-on-eval)
+  ;; 3. Load the library
+
+  (if (and (tangld-load-library-on-build-p
+            inc))
+      (tangld-build-load-library inc))
+  ;; 4. Tangle the source files
+  (mapcar (lambda (f)
+            ((tangld-log-message 3 "Tangling '%s'" f)
+             (org-babel-tangle-file f)))
+          src)
+  ;; 5. Run any post-build hooks
+  (run-hooks 'tangld-post-build-hook))
+
+
+;;;; library files
+(defun tangld-build-load-library (lib-files &optional clear)
+  "Ingest org-mode files into a library of babel for use by other source blocks
+if LIB-FILES is a list of one or more files, use them for the library-of-babel
+
+if CLEAR is non-nil, clear prior to loading"
+  (interactive)
+  (setq org-confirm-babel-evaluate tangld-confirm-on-eval)
+  (let ((clear-p (or (clear tangld-clear-library-before-build-p))))
+  (if (clear-p (tangld--clear-library)))
+  (mapcar (lambda (f)
+            ((tangld-log-message 3 "Loading library '%s'" f)
+             (org-babel-lob-ingest f)))
+             lib-files)))
+
+
+;;;; Find files
+
+(defun tangld-build-file-filter (file root &rest args)
+  "Compare FILE to the regexen in ARGS.  ROOT is the root of the tangld project.
+                `:files'       matches against the file name (with extension)
+                `:exclude'     unless the match this
+                `:include'     cancel the exclusion for these
+                `:exclude-dir' don't look in these subdirectories"
+  (interactive)
+  (let* ((file-regex    (or (plist-get args :files) tangld-build-file-regex))
+         (exclude-regex (or (plist-get args :exclude) tangld-build-file-exclude-regex))
+         (include-regex (or (plist-get args :include) tangld-build-file-include-regex))
+         (exl-dir-regex (or (plist-get args :exclude-dir) tangld-build-dir-exclude-regex))
+         (root-dir      (or root (f-dirname file)))
+         (file-path-dirs  (f-split (f-relative (f-dirname file) root-dir)))
+         (file-name (f-filename file)))
+        ;;;; debugging ;;;;
+    (tangld-log-message 4 "filter: args %s" args)
+    (tangld-log-message 4 "filter: the files property is %s" (plist-get args :files))
+    (tangld-log-message 4 "filter: applying filters to %s in %s" file root)
+    (if (f-file? file) (tangld-log-message 4 "        - PASS: %s is a file" file)
+      (tangld-log-message 4 "        - FAIL: %s is not a file" file))
+    (if (-none? #'(lambda (dir)
+                    (tangld-log-message 4 "        -      testing dir %s" dir)
+                    (s-matches? exl-dir-regex dir))
+                file-path-dirs)
+        (tangld-log-message 4 "        - PASS: No directories match exclusion" exl-dir-regex)
+      (tangld-log-message 4 "        - FAIL: A directory matches exclusion" exl-dir-regex))
+
+    (tangld-log-message 4 "         +----------------------")
+    (if (not (s-matches? exclude-regex file-name))
+        (tangld-log-message 4 "        |  - PASS: %s does not match exclusion %s" file exclude-regex)
+      (tangld-log-message 4  "        |  - FAIL: %s matches exclusion %s" file exclude-regex))
+
+    (if (s-matches? include-regex file-name)
+        (tangld-log-message 4 "        |  - PASS: %s matches inclusion %s" file include-regex)
+      (tangld-log-message 4 "        |  - FAIL: %s does not match inclusion %s" file include-regex))
+
+    (if (or (not (s-matches? exclude-regex file-name))
+            (s-matches? include-regex file-name))
+        (tangld-log-message 4 "        - PASS: %s matches ex/inclusion test" file)
+      (tangld-log-message 4 "        - FAIL: %s does not match ex/inclusion test" file))
+    ;; multiple tests on the file, all need to be true to return true
+    (and
+                                        ; it is a file
+     (f-file? file)
+                                        ; none of the directories below the root match the directory exclusion
+     (-none? #'(lambda (dir)
+                 (s-matches? exl-dir-regex dir))
+             file-path-dirs)
+                                        ; the file name does not match the filename exclusion
+     (or (not (s-matches? exclude-regex file-name))
+                                        ; it matches the file inclusion (canceling the exclusion)
+         (s-matches? include-regex file-name)))))
+
+(defun tangld-build-find-files (dir &rest args)
+  "Collect all files in DIR.  The files are passed to `tangld-build-file-filter'"
+  (interactive)
+  (tangld-log-message 4 "find: looking for files in %s" dir)
+  (tangld-log-message 4 "      - recurse is %s" (plist-get args :recurse))
+  (tangld-log-message 4 "      - files regex is %s" (plist-get args :files))
+  (let ((recurse-p (plist-get args :recurse)))
+    (f--files dir
+              (apply #'tangld-build-file-filter it dir args)
+              recurse-p)))
+
+
+;;; tangld-build.el ends here

--- a/src/tangld-build.el
+++ b/src/tangld-build.el
@@ -86,8 +86,8 @@ each file prior to tangle."
   (run-hooks 'tangld-pre-build-hook)
   ;; 2. Set options that control tangling
   (setq org-confirm-babel-evaluate tangld-confirm-on-eval)
+  (if (cfg) (funcall cfg))
   ;; 3. Load the library
-
   (if (and (tangld-load-library-on-build-p
             inc))
       (tangld-build-load-library inc))

--- a/src/tangld-build.el
+++ b/src/tangld-build.el
@@ -93,8 +93,11 @@ each file prior to tangle."
       (tangld-build-load-library inc))
   ;; 4. Tangle the source files
   (mapcar (lambda (f)
-            ((tangld-log-message 3 "Tangling '%s'" f)
-             (org-babel-tangle-file f)))
+            (if (tangld-file-changed-p f)
+                ((tangld-log-message 3 "Tangling '%s'" f)
+                 (org-babel-tangle-file f)
+                 (tangld-file-last-checksum-put f))
+              (tangld-log-message 3 "'%s' no changes since last tangle" f)))
           src)
   ;; 5. Run any post-build hooks
   (run-hooks 'tangld-post-build-hook))

--- a/src/tangld.el
+++ b/src/tangld.el
@@ -146,7 +146,7 @@
 
 ;;;; Projects
 
-(defun tangld-project-generate (name doc src inc)
+(defun tangld-project-generate (name doc src inc cfg)
   "Add a project definition to the list `tangld-projects-plist'.
 NAME is a unique name given to the project.  This is used in other functions like 
 `tangld-build-project' <name>
@@ -166,9 +166,13 @@ INC is a list of files to be ingested into the library of babel prior to tanglin
         (includes (-map (lambda (f)
                               (tangld-log-message 3 "      '%s' is in list" f)
                           f)
-                        inc)))
+                        inc))
+        ;; Also, the config settings don't need to be processed here right now, so I'm
+        ;; just leaving this "place-holder" for future config processing prior to generating
+        ;; the project 
+        (config cfg))
         (tangld-log-message 2 "adding %s to projects-plist" name)
-    (setq tangld-projects-plist (plist-put tangld-projects-plist name (list sources includes)))))
+    (setq tangld-projects-plist (plist-put tangld-projects-plist name (list sources includes config)))))
 
 
 (defmacro tangld-project-define (name &optional doc &rest project-plist)
@@ -188,11 +192,17 @@ or a path description:
                      :exclude-dir \"^\\.\"    ; don't look in these subdirs
                      :include \".*default.*\" ; cancel the exclusion for these
                      )
-:include same options as :source"
+:include same options as :source
+
+:config add any customization options here, like:
+
+:config (progn
+    (setq tangld-clear-library-before-build-p t))"
   (declare (indent defun))
   (tangld-log-message 4 "define: project %s" name)
   (let ((source (plist-get project-plist :source))
         (include (plist-get project-plist :include))
+        (config (plist-get project-plist :config))
         (source-files nil)
         (include-files nil))
     (cond ((listp source)
@@ -241,7 +251,7 @@ or a path description:
           )
     (tangld-log-message 4 "      calling generate now:")
     (tangld-log-message 4 (string-join source-files "\n"))
-    `(tangld-project-generate ,name ,doc (quote ,source-files) (quote ,include-files))))
+    `(tangld-project-generate ,name ,doc (quote ,source-files) (quote ,include-files) (quote ,config))))
 
 ;;; tangld.el ends here
 

--- a/src/tangld.el
+++ b/src/tangld.el
@@ -1,0 +1,180 @@
+;;; tangld.el --- literate config development environment -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Timothy Aldrich
+
+;; Author: Timothy Aldrich <timothy.r.aldrich@gmail.com>
+;; Version: 0.0.1
+;; Keywords: tools processes
+;; URL: https://github.com/aldrichtr/tangld
+
+;;; Commentary:
+;; A Literate Programming Environment for configuration files and scripts
+
+;; tangld is an Emacs package that provides 'dotfiles management' features
+;; using Literate Programming paradigms.  Using org-mode files with source
+;; blocks and the tangle functionality, Emacs can be used as an IDE to
+;; document, build, and install configuration files, scripts and other
+;; files on a system.  More details are available in the README.org file.
+
+;;; Code:
+
+; The actual org-babel-tangle library
+(require 'ob-tangle)
+
+
+;;;; Constants
+
+
+
+
+;;;; Global settings
+
+(defgroup tangld nil
+  "Literate Config Manager"
+  :prefix "tangld-")
+
+(defcustom tangld-log-buffer-name "*tangld*"
+  "Default buffer name where tangld logs messages"
+  :group 'tangld
+  :type 'string)
+
+; There's probably a much better way to do this but,
+; I'm wrapping the `tangld-log-message' calls with a test of
+; `tangld-log-level' which is a value from 0 to 4
+(defcustom tangld-log-level 4
+  "Logging level provided by tangld functions.
+   0 = silent no output
+   1 = warnings only
+   2 = informational
+   3 = verbose
+   4 = debugging"
+  :group 'tangld
+  :type 'integer)
+
+(defcustom tangld-project-plist '()
+  "A list of projects used when calling `tangld-build'"
+  :group 'tangld
+  :type '(plist :value-type (group string )))
+
+(defcustom tangld-confirm-on-eval nil
+  "If non-nil, emacs will ask before evaluating code in source blocks"
+  :group 'tangld
+  :type '(choice
+          (const :tag "Don't ask" nil)
+          (const :tag "Ask" t)))
+
+(defcustom tangld-add-src-return-link-comments t
+  "Add a link to the source code block in the output"
+  :group 'tangld
+  :type 'boolean)
+
+;;;; Logging
+
+(defun tangld-log-message (lvl msg &rest args)
+  "Log messages to the tangld log buffer"
+  (let ((log-msg (apply #'format msg args)))
+    (if (<= lvl tangld-log-level)
+        (print log-msg (get-buffer-create tangld-log-buffer-name)))))
+
+
+;;;; Projects
+
+(defun tangld-project-generate (name doc src inc)
+  "Add a project definition to the list `tangld-projects-plist'.
+NAME is a unique name given to the project.  This is used in other functions like 
+`tangld-build-project' <name>
+DOC is a short docstring description of the project
+SRC is a list of files to be tangled (each of these will be processed by `org-babel-tangle'
+INC is a list of files to be ingested into the library of babel prior to tangling `org-babel-lob-ingest'"
+  (interactive)
+      (tangld-log-message 2 "generate: %s %s" name doc)
+      (tangld-log-message 2 "          - sources %s" src)
+      ;; TODO right now I don't need to do anything but add the files in src and lib to a list
+      ;; and provide some status.  Later, additional processing can be added here first, prior to
+      ;; adding it to the projects list.
+  (let ((sources (-map (lambda (f)
+                             (tangld-log-message 3 "      '%s' is in list" f)
+                         f)
+                       src))
+        (includes (-map (lambda (f)
+                              (tangld-log-message 3 "      '%s' is in list" f)
+                          f)
+                        inc)))
+        (tangld-log-message 2 "adding %s to projects-plist" name)
+    (setq tangld-projects-plist (plist-put tangld-projects-plist name (list sources includes)))))
+
+
+(defmacro tangld-project-define (name &optional doc &rest project-plist)
+  "define a tangld project.  NAME is a unique name for this project.  DOC is a short description
+and PROJECT-PLIST is a plist of files or search criteria.  The properties of the plist are:
+
+:source either a list of files like 
+
+:source (\"fileA.org\" \"fileB.org\") 
+
+or a path description:
+
+:source (:path \"~/.tangld/src\"        ; root directory to traverse
+                     :recurse t             ; look in subdirectories
+                     :files \"\\.org$\"       ; files to add to source
+                     :exclude \"^\\.\"        ; unless they match this
+                     :exclude-dir \"^\\.\"    ; don't look in these subdirs
+                     :include \".*default.*\" ; cancel the exclusion for these
+                     )
+:include same options as :source"
+  (declare (indent defun))
+  (tangld-log-message 4 "define: project %s" name)
+  (let ((source (plist-get project-plist :source))
+        (include (plist-get project-plist :include))
+        (source-files nil)
+        (include-files nil))
+    (cond ((listp source)
+           (tangld-log-message 4 "        - source is a list %s" source)
+           (if (plist-get source :path)
+               (progn
+                 (tangld-log-message 4 "          - A path spec is included. Pass them to tangld-build-find-files")
+                 (setq source-files (tangld-build-find-files (plist-get source :path)
+                                                             :recurse (plist-get source :recurse)
+                                                             :files   (plist-get source :files)
+                                                             :exclude (plist-get source :exclude)
+                                                             :exclude-dir (plist-get source :exclude-dir)
+                                                             :include (plist-get source :include)))
+                 (tangld-log-message 4 "         - now source files are:")
+                 (tangld-log-message 4 (string-join source-files "\n")))
+             (progn
+               (tangld-log-message 4 "           - source is a list of files %s" source)
+               (tangld-log-message 4 "           - add them to the list of source-files : %s" source-files )
+               (setq source-files source))))
+          ((stringp source)
+           (tangld-log-message 4 "           - sources is a string: '%s' if its a dir we'd expand" source))
+          (t
+           (tangld-log-message 4 "sources is something else '%s'" source))
+          )
+    (cond ((listp include)
+           (tangld-log-message 4 "        - include is a list %s" include)
+           (if (plist-get include :path)
+               (progn
+                 (tangld-log-message 4 "          - A path spec is included. Pass them to tangld-build-find-files")
+                 (setq include-files (tangld-build-find-files (plist-get include :path)
+                                                              :recurse (plist-get include :recurse)
+                                                              :files   (plist-get include :files)
+                                                              :exclude (plist-get include :exclude)
+                                                              :exclude-dir (plist-get include :exclude-dir)
+                                                              :include (plist-get include :include)))
+                 (tangld-log-message 4 "         - now include files are:")
+                 (tangld-log-message 4 (string-join include-files "\n")))
+             (progn
+               (tangld-log-message 4 "           - include is a list of files %s" include)
+               (tangld-log-message 4 "           - add them to the list of include-files : %s" include-files )
+               (setq include-files include))))
+          ((stringp include)
+           (tangld-log-message 4 "           - includes is a string: '%s' if its a dir we'd expand" include))
+          (t
+           (tangld-log-message 4 "includes is something else '%s'" include))
+          )
+    (tangld-log-message 4 "      calling generate now:")
+    (tangld-log-message 4 (string-join source-files "\n"))
+    `(tangld-project-generate ,name ,doc (quote ,source-files) (quote ,include-files))))
+
+;;; tangld.el ends here
+

--- a/src/tangld.el
+++ b/src/tangld.el
@@ -130,9 +130,10 @@
   "Get a checksum from the database"
   (gethash path tangld-file-tracking-db))
 
-(defun tangld-file-last-checksum-put (path chksum)
+(defun tangld-file-last-checksum-put (path &optional chksum)
   "Add or update a checksum to the database"
-  (puthash path chksum tangld-file-tracking-db))
+  (let ((checksum (or chksum (tangld-compute-file-hash path))))
+    (puthash path checksum tangld-file-tracking-db)))
 
 (defun tangld-file-tracking-db-init ()
   (let ((db  (make-hash-table


### PR DESCRIPTION
## Overview
An initial set of variables, macros and functions to define a tangld-project and "run" it.

At this point, all the basic functionality to define a project of sources, includes and configuration, and then pass that to `tangld-build-project` which in turn calls `tangld-build`.  That function ultimately :
- runs any pre-build hooks
- loads the library-of-babel if needed
- tangles each file that has not changed

## Additional / supporting features
- A rudimentary logging system.  Write messages to a logging buffer, with a set of "logging levels" similar to other logging packages
- A checksum system.  In order to determine if a file has changed since the last time it was tangled (if ever), a checksum of the current file is compared to a hashtable of path => checksum (SHA1).
  Several functions for reading and writing the database to disk, getting and setting entries in the db, etc.

## Other
- Updated the readme with the syntax and description of a tangld-project.